### PR TITLE
support INCLUDE type of RoutingRule

### DIFF
--- a/src/config/convert.js
+++ b/src/config/convert.js
@@ -6,10 +6,10 @@ const electron = require('electron')
 const { app } = electron
 const path = require('path')
 const fs = require('fs')
-let configFolder = path.join(app.getPath('userData'), 'config')
 
 const readConfig = (config) => {
-  const fullpath = path.join(configFolder, config)
+  let configFolder = path.join(app.getPath('userData'), 'config')
+  let fullpath = path.join(configFolder, config)
   return fs.readFileSync(fullpath, 'utf-8')
 }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3,6 +3,7 @@
   "Disconnect": "Disconnect",
   "Reconnect": "Reconnect",
   "Edit Selected": "Edit Selected",
+  "Edit Include Config": "Edit Include Config",
   "No selected config.": "No selected config.",
   "Create Config": "Create Config",
   "Create Conf Template": "Create Conf Template",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -3,6 +3,7 @@
   "Disconnect": "断开连接",
   "Reconnect": "重新连接",
   "Edit Selected": "编辑选中配置",
+  "Edit Include Config": "编辑导入配置",
   "No selected config.": "没有选中配置。",
   "Create Config": "新建配置",
   "Create Conf Template": "新建 Conf 配置模板",

--- a/src/main.js
+++ b/src/main.js
@@ -1127,6 +1127,8 @@ function buildTrayMenu() {
   if (configs.length > 0) {
     mainMenus.push({ type: 'separator' })
   }
+  const subConfigs = fs.readdirSync(configFolder).filter(x => (x.match(/^[^.].*(\.list)$/g)))
+
   mainMenus.push({
     label: i18n.t('Edit Selected'),
     type: 'normal',
@@ -1249,6 +1251,19 @@ function buildTrayMenu() {
         })
       }
     }])
+  }, {
+    label: i18n.t('Edit Include Config'),
+    type: 'submenu',
+    submenu: Menu.buildFromTemplate(subConfigs.map((config) => {
+      return {
+        label: config,
+        type: 'normal',
+        click: function() {
+          const fullpath = path.join(configFolder, config)
+          shell.openItem(fullpath)
+        }
+      }
+    }))
   })
   mainMenus.push({
     label: i18n.t('Config Folder'),

--- a/src/main.js
+++ b/src/main.js
@@ -459,7 +459,17 @@ async function startCore(callback) {
   if (selectedConfig.includes('.conf')) {
     try {
       const content = fs.readFileSync(selectedConfig, 'utf-8')
-      v2json = convert.constructJson(content)
+      let subConfig = {}
+      
+      routingRuleSubConfig = convert.readSubConfigBySection(content, 'RoutingRule')
+      if (routingRuleSubConfig.length != 0) {
+        subConfig['RoutingRule'] = {}
+        routingRuleSubConfig.forEach((filename) => {
+          subConfig['RoutingRule'][filename] = fs.readFileSync(path.join(configFolder, filename), 'utf-8')
+        })
+      }
+      
+      v2json = convert.constructJson(content, subConfig)
     } catch(err) {
       dialog.showErrorBox('Error', 'Config error: ' +  err)
       return


### PR DESCRIPTION
Support feature at #60.

### Note:

1. `[RoutingRule]` in `.list` file is needed.
2. `INCLUDE` is **only** supported in `[RoutingRule]` section.

### Example:

**proxy.conf:**

```
[Endpoint]
Proxy, ss, ss://xxxx:xxxxx@ip:port
Direct, builtin, freedom

[RoutingRule]
PROCESS-NAME, ss-local, Direct
INCLUDE, cn_with_target.list
; INCLUDE, cn_without_target.list, Direct
FINAL, Proxy
```

**cn_with_target.list:**
```
[RoutingRule]
PROCESS-NAME, QQ, Direct
DOMAIN-KEYWORD, geosite:cn, Direct
GEOIP, cn, Direct
```

**cn_without_target.list**
```
[RoutingRule]
PROCESS-NAME, QQ
DOMAIN-KEYWORD, geosite:cn
GEOIP, cn
```